### PR TITLE
Do not set readonly property Symbol

### DIFF
--- a/Blob.js
+++ b/Blob.js
@@ -582,9 +582,9 @@
 		}
 
 		if (strTag) {
-			exports.File.prototype[strTag] = "File";
-			exports.Blob.prototype[strTag] = "Blob";
-			exports.FileReader.prototype[strTag] = "FileReader";
+			if (!exports.File.prototype[strTag]) exports.File.prototype[strTag] = "File";
+			if (!exports.Blob.prototype[strTag]) exports.Blob.prototype[strTag] = "Blob";
+			if (!exports.FileReader.prototype[strTag]) exports.FileReader.prototype[strTag] = "FileReader";
 		}
 
 		var blob = exports.Blob.prototype;

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,10 @@ describe("blob-polyfill", function () {
 			assert.strictEqual(blob.size, 3);
 			assert.strictEqual(blob.type, "application/octet-binary");
 		});
+
+		it("Symbol is Blob", function () {
+			assert.strictEqual(Blob.prototype[Symbol.toStringTag], "Blob");
+		});
 	});
 
 	describe("File", function () {
@@ -52,6 +56,10 @@ describe("blob-polyfill", function () {
 			assert.strictEqual(file.type, "");
 			assert.strictEqual(file.name, "");
 		});
+
+		it("Symbol is File", function () {
+			assert.strictEqual(File.prototype[Symbol.toStringTag], "File");
+		});
 	});
 
 	describe("FileReader", function () {
@@ -67,6 +75,10 @@ describe("blob-polyfill", function () {
 			var fileReader = new FileReader();
 
 			assert.ok(fileReader);
+		});
+
+		it("Symbol is FileReader", function () {
+			assert.strictEqual(FileReader.prototype[Symbol.toStringTag], "FileReader");
 		});
 	});
 


### PR DESCRIPTION
If there is already a symbol don't try to set it. We want to avoid writing to a readonly property in environments that prevent writing to these properties.

This should address an issue identified in #7 