### PR TITLE
Test that data round trips for ArrayBuffer, some fixes

### DIFF
--- a/Blob.js
+++ b/Blob.js
@@ -256,7 +256,7 @@
 
 		function FakeBlobBuilder () {
 			function isDataView (obj) {
-				return obj && Object.prototype.isPrototypeOf(DataView, obj);
+				return obj && Object.prototype.isPrototypeOf.call(DataView.prototype, obj);
 			}
 			function bufferClone (buf) {
 				var view = new Array(buf.byteLength);
@@ -352,10 +352,10 @@
 						chunks[i] = chunk._buffer;
 					} else if (typeof chunk === "string") {
 						chunks[i] = textEncode(chunk);
-					} else if (arrayBufferSupported && (Object.prototype.isPrototypeOf(ArrayBuffer, chunk) || isArrayBufferView(chunk))) {
+					} else if (arrayBufferSupported && (Object.prototype.isPrototypeOf.call(ArrayBuffer.prototype, chunk) || isArrayBufferView(chunk))) {
 						chunks[i] = bufferClone(chunk);
 					} else if (arrayBufferSupported && isDataView(chunk)) {
-						chunks[i] = bufferClone(chunk.buffer === undefined ? chunk : chunk.buffer);
+						chunks[i] = bufferClone(chunk.buffer);
 					} else {
 						chunks[i] = textEncode(String(chunk));
 					}

--- a/Blob.js
+++ b/Blob.js
@@ -256,7 +256,7 @@
 
 		function FakeBlobBuilder () {
 			function isDataView (obj) {
-				return obj && Object.prototype.isPrototypeOf.call(DataView, obj);
+				return obj && Object.prototype.isPrototypeOf(DataView, obj);
 			}
 			function bufferClone (buf) {
 				var view = new Array(buf.byteLength);
@@ -352,10 +352,10 @@
 						chunks[i] = chunk._buffer;
 					} else if (typeof chunk === "string") {
 						chunks[i] = textEncode(chunk);
-					} else if (arrayBufferSupported && (Object.prototype.isPrototypeOf.call(ArrayBuffer, chunk) || isArrayBufferView(chunk))) {
+					} else if (arrayBufferSupported && (Object.prototype.isPrototypeOf(ArrayBuffer, chunk) || isArrayBufferView(chunk))) {
 						chunks[i] = bufferClone(chunk);
 					} else if (arrayBufferSupported && isDataView(chunk)) {
-						chunks[i] = bufferClone(chunk.buffer);
+						chunks[i] = bufferClone(chunk.buffer === undefined ? chunk : chunk.buffer);
 					} else {
 						chunks[i] = textEncode(String(chunk));
 					}

--- a/Blob.js
+++ b/Blob.js
@@ -352,7 +352,11 @@
 						chunks[i] = chunk._buffer;
 					} else if (typeof chunk === "string") {
 						chunks[i] = textEncode(chunk);
-					} else if (arrayBufferSupported && (Object.prototype.isPrototypeOf.call(ArrayBuffer.prototype, chunk) || isArrayBufferView(chunk))) {
+					} else if (
+						arrayBufferSupported && (
+							Object.prototype.isPrototypeOf.call(ArrayBuffer.prototype, chunk)
+							|| isArrayBufferView(chunk)
+							|| toString.call(chunk) === "[object ArrayBuffer]")) {
 						chunks[i] = bufferClone(chunk);
 					} else if (arrayBufferSupported && isDataView(chunk)) {
 						chunks[i] = bufferClone(chunk.buffer);

--- a/test/index.js
+++ b/test/index.js
@@ -51,6 +51,16 @@ describe("blob-polyfill", function () {
 				is.assert.arrayBuffer(value);
 			});
 		});
+
+		it("Blob can be instantiated with ArrayBuffer, data can be recovered", function () {
+			var testString = "Testing...";
+			var arrayBuffer = stringToArrayBuffer(testString);
+			var blob = new Blob([arrayBuffer]);
+			return blob.arrayBuffer().then(function (value) {
+				var testStringRecovered = arrayBufferToString(value);
+				assert.strictEqual(testString, testStringRecovered);
+			});
+		});
 	});
 
 	describe("File", function () {
@@ -106,3 +116,18 @@ describe("blob-polyfill", function () {
 		});
 	});
 });
+
+
+function stringToArrayBuffer(string) {
+	const buf = new ArrayBuffer(string.length * 2); // 2 bytes for each char
+	const bufView = new Uint16Array(buf);
+	for (let i = 0, strLen = string.length; i < strLen; i++) {
+		bufView[i] = string.charCodeAt(i);
+	}
+	return buf;
+}
+
+function arrayBufferToString(buffer) {
+	const array = new Uint16Array(buffer);
+	return String.fromCharCode.apply(null, array);
+}


### PR DESCRIPTION
The following issue describes using blob-polyfill or similar to fix an issue with Blob support on fake-indexeddb:
https://github.com/dumbmatter/fakeIndexedDB/issues/56

This is the scenario I'm using it in, but unfortunately, it seems not to work for Blobs wrapping ArrayBuffer/DataView.  These changes seem to fix it.  A test is also provided, although doesn't fully repro one of the issues I encountered.  Specifically in this case, the chunk tests as DataView, but has no buffer property.  I add the fix to this PR even though I was unable to repro in a test.