### PR TITLE
Change `Blob.prototype` to `global.Blob.prototype`

### DIFF
--- a/Blob.js
+++ b/Blob.js
@@ -93,8 +93,8 @@
 		}
 
 		if (global.Blob) {
-			BlobBuilderConstructor.prototype = Blob.prototype;
-			BlobConstructor.prototype = Blob.prototype;
+			BlobBuilderConstructor.prototype = global.Blob.prototype;
+			BlobConstructor.prototype = global.Blob.prototype;
 		}
 
 		/********************************************************/


### PR DESCRIPTION
When using Webpack's `ProvidePlugin` to shim all instances of `Blob` in the bundle with this polyfill, Webpack will generate a var declaration that looks something like like this:

```typescript
var Blob = __webpack_require__(203)["Blob"];

// The rest of this polyfill
(function(global)) {

}
```

If there is already a globally defined `Blob`, `global.Blob` will not necessarily be the same as just `Blob`. The exact error we are seeing is `TypeError: Cannot read properties of undefined (reading 'prototype')` (which indicates that in this case, `Blob` is undefined.) We are hitting this because we'd like to start providing `Blob` as a server-side runtime API, but clients may still be polyfilling with the `ProvidePlugin`.