### PR TITLE
Use exported FileReader

### DIFF
--- a/Blob.js
+++ b/Blob.js
@@ -687,7 +687,7 @@ function array2base64 (input) {
 
 		if (!blob.arrayBuffer) {
 			blob.arrayBuffer = function arrayBuffer() {
-				var fr = new FileReader();
+				var fr = new exports.FileReader();
 				fr.readAsArrayBuffer(this);
 				return promisify(fr);
 			};
@@ -695,7 +695,7 @@ function array2base64 (input) {
 
 		if (!blob.text) {
 			blob.text = function text() {
-				var fr = new FileReader();
+				var fr = new exports.FileReader();
 				fr.readAsText(this);
 				return promisify(fr);
 			};


### PR DESCRIPTION
We're encountering the following issue:
```
TypeError: Cannot read properties of undefined (reading 'buffer')
    at FileReader.readAsArrayBuffer (blob-polyfill/Blob.js:596:32)
    at Blob.arrayBuffer (blob-polyfill/Blob.js:691:8)
```

It looks like when we import the polyfill, we end up with the existing global Blob and FileReader objects, but the `Blob.arrayBuffer` function is being added. In the [most recent commit](https://github.com/bjornstar/blob-polyfill/commit/3dbf7cbd5d73be04141f4d3049b694ee7941adcb#diff-664a3db367a9be3b91cc4c9f4908dfeb486121ce4ff9de7fc6c5666cf34106db), the FileReader definition was moved, so it now exists in the same scope as `Blob.arrayBuffer`.

As a result, `Blob.arrayBuffer` now always uses the fake `FileReader`, regardless of whether or not it was polyfilled. This is breaking on our blobs as they don't have a `_buffer`, which seems to be only present on the fake `Blob`.